### PR TITLE
ci: remove github from publishing

### DIFF
--- a/packages/react-microsurveys-client/project.json
+++ b/packages/react-microsurveys-client/project.json
@@ -76,10 +76,7 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "postTargets": [
-          "react-microsurveys-client:publish",
-          "react-microsurveys-client:github"
-        ],
+        "postTargets": ["react-microsurveys-client:publish"],
         "preset": "conventional"
       }
     },

--- a/packages/react-microsurveys-editor/project.json
+++ b/packages/react-microsurveys-editor/project.json
@@ -76,10 +76,7 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "postTargets": [
-          "react-microsurveys-editor:publish",
-          "react-microsurveys-editor:github"
-        ],
+        "postTargets": ["react-microsurveys-editor:publish"],
         "preset": "conventional"
       }
     },

--- a/packages/react-microsurveys/project.json
+++ b/packages/react-microsurveys/project.json
@@ -74,10 +74,7 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "postTargets": [
-          "react-microsurveys:publish",
-          "react-microsurveys:github"
-        ],
+        "postTargets": ["react-microsurveys:publish"],
         "preset": "conventional"
       }
     },

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -31,7 +31,7 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "postTargets": ["types:publish", "types:github"],
+        "postTargets": ["types:publish"],
         "preset": "conventional"
       }
     },


### PR DESCRIPTION
Temporarily remove github post-publish until https://github.com/jscutlery/semver/issues/561 is fixed.