### PR TITLE
Fix webpack executor output

### DIFF
--- a/packages/microsurveys-step/project.json
+++ b/packages/microsurveys-step/project.json
@@ -19,7 +19,14 @@
         "main": "packages/microsurveys-step/src/lib/RunnerPackage/RunnerPackage.ts",
         "outputPath": "dist/packages/microsurveys-step",
         "tsConfig": "packages/microsurveys-step/tsconfig.lib.json",
-        "webpackConfig": "packages/microsurveys-step/webpack.config.js"
+        "webpackConfig": "packages/microsurveys-step/webpack.config.js",
+        "assets": [
+          {
+            "glob": "packages/microsurveys-step/package.json",
+            "input": ".",
+            "output": "."
+          }
+        ]
       },
       "defaultConfiguration": "production",
       "configurations": {


### PR DESCRIPTION
This PR aims to complete the bundling and publishing of the microsurvey step by fixing the output files and copying over the package.json after bundling.