### PR TITLE
feat: pass container to microsurvey

### DIFF
--- a/packages/microsurveys-step/src/lib/App/App.tsx
+++ b/packages/microsurveys-step/src/lib/App/App.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 export interface AppProps {
   form: Form;
   anchorEl?: Element;
+  container?: Element;
   currentQuestion: number;
   onSubmit?: (response: Response) => void;
   onClosed?: () => void;

--- a/packages/microsurveys-step/src/lib/StepRunner/StepRunner.spec.ts
+++ b/packages/microsurveys-step/src/lib/StepRunner/StepRunner.spec.ts
@@ -53,7 +53,7 @@ describe('StepRunner', () => {
             form: props.form,
             anchorEl: undefined,
           }),
-          runner.container,
+          runner.shadowRoot,
           runner.emotionRoot
         );
       });
@@ -71,7 +71,7 @@ describe('StepRunner', () => {
             form: props.form,
             anchorEl: document.getElementById('test'),
           }),
-          runner.container,
+          runner.shadowRoot,
           runner.emotionRoot
         );
       });

--- a/packages/microsurveys-step/src/lib/StepRunner/StepRunner.ts
+++ b/packages/microsurveys-step/src/lib/StepRunner/StepRunner.ts
@@ -25,6 +25,7 @@ export class StepRunner extends Step<Props> {
 
     // https://mui.com/material-ui/guides/shadow-dom/
     this.container = document.createElement('div');
+    this.container.setAttribute('id', 'samelogic-root');
     document.body.appendChild(this.container);
 
     const shadowContainer = this.container.attachShadow({ mode: 'open' });
@@ -52,6 +53,7 @@ export class StepRunner extends Step<Props> {
   private render(props: Props): void {
     const anchorEl = document.querySelector(props.anchorElCssSelector);
     const appProps: AppProps = {
+      container: this.container,
       onSubmit: (resp: Response) =>
         this.onEventTriggered?.({
           stepName: this.name,


### PR DESCRIPTION
This should prevent Popper from appending its elements to document.body but rather in the shadow dom.

reference:
https://mui.com/material-ui/api/popper/
